### PR TITLE
Add search controls to ingredient form

### DIFF
--- a/src/main/java/org/cafeteria/cafeteria/controller/IngredienteFormController.java
+++ b/src/main/java/org/cafeteria/cafeteria/controller/IngredienteFormController.java
@@ -6,12 +6,17 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.Alert;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.Label;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
 import javafx.scene.control.TextArea;
 import javafx.scene.control.TextField;
 import org.cafeteria.cafeteria.config.JPAUtil;
 import org.cafeteria.cafeteria.model.Ingrediente;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class IngredienteFormController {
     @FXML private TextField nombreField;
@@ -22,8 +27,12 @@ public class IngredienteFormController {
     @FXML private TableColumn<Ingrediente, String> nombreColumn;
     @FXML private TableColumn<Ingrediente, String> descripcionColumn;
     @FXML private TableColumn<Ingrediente, String> preparacionColumn;
+    @FXML private ComboBox<String> searchFieldCombo;
+    @FXML private TextField searchTextField;
 
     private final ObservableList<Ingrediente> ingredientes = FXCollections.observableArrayList();
+    private List<Ingrediente> ingredientesCache = new ArrayList<>();
+    private boolean listaCompletaCargada = false;
 
     @FXML
     private void initialize() {
@@ -33,6 +42,7 @@ public class IngredienteFormController {
         preparacionColumn.setCellValueFactory(cell -> new ReadOnlyObjectWrapper<>(cell.getValue().preparacion));
 
         ingredientesTable.setItems(ingredientes);
+        ingredientesTable.setPlaceholder(new Label("Realiza una búsqueda o presiona \"Listar\" para ver registros"));
         ingredientesTable.getSelectionModel().selectedItemProperty().addListener((obs, old, selected) -> {
             if (selected != null) {
                 nombreField.setText(selected.nombre);
@@ -41,7 +51,26 @@ public class IngredienteFormController {
             }
         });
 
+        if (searchFieldCombo != null) {
+            searchFieldCombo.setItems(FXCollections.observableArrayList("ID", "Nombre", "Descripción", "Preparación"));
+            searchFieldCombo.setPromptText("Campo");
+            searchFieldCombo.valueProperty().addListener((obs, old, value) -> buscarYActualizarTabla());
+        }
+        if (searchTextField != null) {
+            searchTextField.textProperty().addListener((obs, old, value) -> buscarYActualizarTabla());
+        }
+    }
+
+    @FXML
+    private void onList() {
         loadIngredientes();
+        if (searchFieldCombo != null) {
+            searchFieldCombo.getSelectionModel().clearSelection();
+        }
+        if (searchTextField != null) {
+            searchTextField.clear();
+        }
+        actualizarPlaceholder();
     }
 
     @FXML
@@ -150,6 +179,13 @@ public class IngredienteFormController {
         descripcionArea.clear();
         preparacionArea.clear();
         ingredientesTable.getSelectionModel().clearSelection();
+        if (searchFieldCombo != null) {
+            searchFieldCombo.getSelectionModel().clearSelection();
+        }
+        if (searchTextField != null) {
+            searchTextField.clear();
+        }
+        buscarYActualizarTabla();
         nombreField.requestFocus();
     }
 
@@ -159,11 +195,89 @@ public class IngredienteFormController {
             var lista = em.createQuery("select i from Ingrediente i order by i.idIngrediente", Ingrediente.class)
                     .getResultList();
             ingredientes.setAll(lista);
+            ingredientesCache = new ArrayList<>(lista);
+            listaCompletaCargada = true;
+            ingredientesTable.getSelectionModel().clearSelection();
+            actualizarPlaceholder();
         } catch (Exception ex) {
             alert(Alert.AlertType.ERROR, "Error al cargar", ex.getMessage());
             ex.printStackTrace();
+            listaCompletaCargada = false;
         } finally {
             em.close();
+        }
+    }
+
+    private void buscarYActualizarTabla() {
+        String campo = searchFieldCombo != null ? searchFieldCombo.getValue() : null;
+        String termino = searchTextField != null ? searchTextField.getText() : null;
+
+        if (campo == null || termino == null || termino.isBlank()) {
+            if (listaCompletaCargada) {
+                ingredientes.setAll(ingredientesCache);
+            } else {
+                ingredientes.clear();
+            }
+            ingredientesTable.getSelectionModel().clearSelection();
+            actualizarPlaceholder();
+            return;
+        }
+
+        EntityManager em = JPAUtil.em();
+        try {
+            List<Ingrediente> resultados = switch (campo) {
+                case "ID" -> buscarPorId(em, termino);
+                case "Nombre" -> buscarPorTexto(em, "nombre", termino);
+                case "Descripción" -> buscarPorTexto(em, "descripcion", termino);
+                case "Preparación" -> buscarPorTexto(em, "preparacion", termino);
+                default -> List.of();
+            };
+            ingredientes.setAll(resultados);
+            ingredientesTable.getSelectionModel().clearSelection();
+        } catch (Exception ex) {
+            ingredientes.clear();
+            alert(Alert.AlertType.ERROR, "Error de búsqueda", ex.getMessage());
+        } finally {
+            em.close();
+        }
+        actualizarPlaceholder();
+    }
+
+    private List<Ingrediente> buscarPorId(EntityManager em, String termino) {
+        try {
+            Long id = Long.parseLong(termino.trim());
+            return em.createQuery("select i from Ingrediente i where i.idIngrediente = :id", Ingrediente.class)
+                    .setParameter("id", id)
+                    .getResultList();
+        } catch (NumberFormatException e) {
+            return List.of();
+        }
+    }
+
+    private List<Ingrediente> buscarPorTexto(EntityManager em, String campo, String termino) {
+        String patron = "%" + termino.toLowerCase().trim() + "%";
+        return em.createQuery(
+                        "select i from Ingrediente i where lower(i." + campo + ") like :pattern order by i.idIngrediente",
+                        Ingrediente.class)
+                .setParameter("pattern", patron)
+                .getResultList();
+    }
+
+    private void actualizarPlaceholder() {
+        if (!ingredientes.isEmpty()) {
+            ingredientesTable.setPlaceholder(new Label(""));
+            return;
+        }
+
+        boolean hayBusquedaActiva = searchFieldCombo != null && searchFieldCombo.getValue() != null
+                && searchTextField != null && searchTextField.getText() != null && !searchTextField.getText().isBlank();
+
+        if (hayBusquedaActiva) {
+            ingredientesTable.setPlaceholder(new Label("No se encontró en la base de datos"));
+        } else if (listaCompletaCargada) {
+            ingredientesTable.setPlaceholder(new Label("No hay registros disponibles"));
+        } else {
+            ingredientesTable.setPlaceholder(new Label("Realiza una búsqueda o presiona \"Listar\" para ver registros"));
         }
     }
 

--- a/src/main/resources/fxml/IngredienteForm.fxml
+++ b/src/main/resources/fxml/IngredienteForm.fxml
@@ -2,6 +2,7 @@
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
+<?import javafx.scene.layout.Priority?>
 <BorderPane xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1"
             fx:controller="org.cafeteria.cafeteria.controller.IngredienteFormController">
     <center>
@@ -27,6 +28,12 @@
                     </children>
                 </GridPane>
 
+                <HBox spacing="10" alignment="CENTER_LEFT">
+                    <Label text="Buscar por:"/>
+                    <ComboBox fx:id="searchFieldCombo" prefWidth="160"/>
+                    <TextField fx:id="searchTextField" promptText="Escribe para buscar..." HBox.hgrow="ALWAYS"/>
+                </HBox>
+
                 <TableView fx:id="ingredientesTable" prefHeight="250.0">
                     <columns>
                         <TableColumn fx:id="idColumn" text="ID" prefWidth="70.0"/>
@@ -43,6 +50,7 @@
             <padding>
                 <Insets top="10" right="10" bottom="10" left="10"/>
             </padding>
+            <Button text="Listar" onAction="#onList"/>
             <Button text="Guardar" onAction="#onSave" defaultButton="true"/>
             <Button text="Actualizar" onAction="#onUpdate"/>
             <Button text="Eliminar" onAction="#onDelete"/>


### PR DESCRIPTION
## Summary
- add field selection and input controls to the ingredient form for searching records
- implement controller logic to filter ingredients by the chosen field, reuse cached results, and keep table placeholders updated

## Testing
- mvn -q -DskipTests compile

------
https://chatgpt.com/codex/tasks/task_e_68f19be6564c832eb1fe9bc659a362ee