### PR TITLE
Fix ingredient search combo and align form layout

### DIFF
--- a/src/main/java/org/cafeteria/cafeteria/controller/IngredienteFormController.java
+++ b/src/main/java/org/cafeteria/cafeteria/controller/IngredienteFormController.java
@@ -6,12 +6,17 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.Alert;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.Label;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
 import javafx.scene.control.TextArea;
 import javafx.scene.control.TextField;
 import org.cafeteria.cafeteria.config.JPAUtil;
 import org.cafeteria.cafeteria.model.Ingrediente;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class IngredienteFormController {
     @FXML private TextField nombreField;
@@ -22,8 +27,12 @@ public class IngredienteFormController {
     @FXML private TableColumn<Ingrediente, String> nombreColumn;
     @FXML private TableColumn<Ingrediente, String> descripcionColumn;
     @FXML private TableColumn<Ingrediente, String> preparacionColumn;
+    @FXML private ComboBox<String> cmbBusqueda;
+    @FXML private TextField txtBusqueda;
 
     private final ObservableList<Ingrediente> ingredientes = FXCollections.observableArrayList();
+    private List<Ingrediente> ingredientesCache = new ArrayList<>();
+    private boolean listaCompletaCargada = false;
 
     @FXML
     private void initialize() {
@@ -33,6 +42,7 @@ public class IngredienteFormController {
         preparacionColumn.setCellValueFactory(cell -> new ReadOnlyObjectWrapper<>(cell.getValue().preparacion));
 
         ingredientesTable.setItems(ingredientes);
+        ingredientesTable.setPlaceholder(new Label("Realiza una búsqueda o presiona \"Listar\" para ver registros"));
         ingredientesTable.getSelectionModel().selectedItemProperty().addListener((obs, old, selected) -> {
             if (selected != null) {
                 nombreField.setText(selected.nombre);
@@ -41,7 +51,26 @@ public class IngredienteFormController {
             }
         });
 
+        if (cmbBusqueda != null) {
+            cmbBusqueda.setItems(FXCollections.observableArrayList("ID", "Nombre", "Descripción", "Preparación"));
+            cmbBusqueda.setPromptText("Elige un campo...");
+            cmbBusqueda.valueProperty().addListener((obs, old, value) -> buscarYActualizarTabla());
+        }
+        if (txtBusqueda != null) {
+            txtBusqueda.textProperty().addListener((obs, old, value) -> buscarYActualizarTabla());
+        }
+    }
+
+    @FXML
+    private void onList() {
         loadIngredientes();
+        if (cmbBusqueda != null) {
+            cmbBusqueda.getSelectionModel().clearSelection();
+        }
+        if (txtBusqueda != null) {
+            txtBusqueda.clear();
+        }
+        actualizarPlaceholder();
     }
 
     @FXML
@@ -150,6 +179,13 @@ public class IngredienteFormController {
         descripcionArea.clear();
         preparacionArea.clear();
         ingredientesTable.getSelectionModel().clearSelection();
+        if (cmbBusqueda != null) {
+            cmbBusqueda.getSelectionModel().clearSelection();
+        }
+        if (txtBusqueda != null) {
+            txtBusqueda.clear();
+        }
+        buscarYActualizarTabla();
         nombreField.requestFocus();
     }
 
@@ -159,11 +195,89 @@ public class IngredienteFormController {
             var lista = em.createQuery("select i from Ingrediente i order by i.idIngrediente", Ingrediente.class)
                     .getResultList();
             ingredientes.setAll(lista);
+            ingredientesCache = new ArrayList<>(lista);
+            listaCompletaCargada = true;
+            ingredientesTable.getSelectionModel().clearSelection();
+            actualizarPlaceholder();
         } catch (Exception ex) {
             alert(Alert.AlertType.ERROR, "Error al cargar", ex.getMessage());
             ex.printStackTrace();
+            listaCompletaCargada = false;
         } finally {
             em.close();
+        }
+    }
+
+    private void buscarYActualizarTabla() {
+        String campo = cmbBusqueda != null ? cmbBusqueda.getValue() : null;
+        String termino = txtBusqueda != null ? txtBusqueda.getText() : null;
+
+        if (campo == null || termino == null || termino.isBlank()) {
+            if (listaCompletaCargada) {
+                ingredientes.setAll(ingredientesCache);
+            } else {
+                ingredientes.clear();
+            }
+            ingredientesTable.getSelectionModel().clearSelection();
+            actualizarPlaceholder();
+            return;
+        }
+
+        EntityManager em = JPAUtil.em();
+        try {
+            List<Ingrediente> resultados = switch (campo) {
+                case "ID" -> buscarPorId(em, termino);
+                case "Nombre" -> buscarPorTexto(em, "nombre", termino);
+                case "Descripción" -> buscarPorTexto(em, "descripcion", termino);
+                case "Preparación" -> buscarPorTexto(em, "preparacion", termino);
+                default -> List.of();
+            };
+            ingredientes.setAll(resultados);
+            ingredientesTable.getSelectionModel().clearSelection();
+        } catch (Exception ex) {
+            ingredientes.clear();
+            alert(Alert.AlertType.ERROR, "Error de búsqueda", ex.getMessage());
+        } finally {
+            em.close();
+        }
+        actualizarPlaceholder();
+    }
+
+    private List<Ingrediente> buscarPorId(EntityManager em, String termino) {
+        try {
+            Long id = Long.parseLong(termino.trim());
+            return em.createQuery("select i from Ingrediente i where i.idIngrediente = :id", Ingrediente.class)
+                    .setParameter("id", id)
+                    .getResultList();
+        } catch (NumberFormatException e) {
+            return List.of();
+        }
+    }
+
+    private List<Ingrediente> buscarPorTexto(EntityManager em, String campo, String termino) {
+        String patron = "%" + termino.toLowerCase().trim() + "%";
+        return em.createQuery(
+                        "select i from Ingrediente i where lower(i." + campo + ") like :pattern order by i.idIngrediente",
+                        Ingrediente.class)
+                .setParameter("pattern", patron)
+                .getResultList();
+    }
+
+    private void actualizarPlaceholder() {
+        if (!ingredientes.isEmpty()) {
+            ingredientesTable.setPlaceholder(new Label(""));
+            return;
+        }
+
+        boolean hayBusquedaActiva = cmbBusqueda != null && cmbBusqueda.getValue() != null
+                && txtBusqueda != null && txtBusqueda.getText() != null && !txtBusqueda.getText().isBlank();
+
+        if (hayBusquedaActiva) {
+            ingredientesTable.setPlaceholder(new Label("No se encontró en la base de datos"));
+        } else if (listaCompletaCargada) {
+            ingredientesTable.setPlaceholder(new Label("No hay registros disponibles"));
+        } else {
+            ingredientesTable.setPlaceholder(new Label("Realiza una búsqueda o presiona \"Listar\" para ver registros"));
         }
     }
 

--- a/src/main/resources/fxml/IngredienteForm.fxml
+++ b/src/main/resources/fxml/IngredienteForm.fxml
@@ -1,52 +1,56 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?import javafx.geometry.Insets?>
+
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
-<BorderPane xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1"
+
+<AnchorPane xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1"
             fx:controller="org.cafeteria.cafeteria.controller.IngredienteFormController">
-    <center>
-        <VBox spacing="15">
-            <padding>
-                <Insets top="10" right="10" bottom="10" left="10"/>
-            </padding>
-            <children>
-                <GridPane hgap="10" vgap="10">
-                    <columnConstraints>
-                        <ColumnConstraints percentWidth="30"/>
-                        <ColumnConstraints percentWidth="70"/>
-                    </columnConstraints>
-                    <children>
-                        <Label text="Nombre:" GridPane.rowIndex="0" GridPane.columnIndex="0"/>
-                        <TextField fx:id="nombreField" GridPane.rowIndex="0" GridPane.columnIndex="1"/>
+    <children>
+        <VBox spacing="16.0" styleClass="card" AnchorPane.bottomAnchor="0" AnchorPane.leftAnchor="0"
+              AnchorPane.rightAnchor="0" AnchorPane.topAnchor="0">
+            <Label styleClass="h1" text="Ingredientes" />
+            <GridPane hgap="10" vgap="12">
+                <columnConstraints>
+                    <ColumnConstraints percentWidth="30" />
+                    <ColumnConstraints percentWidth="70" />
+                </columnConstraints>
+                <rowConstraints>
+                    <RowConstraints minHeight="30.0" />
+                    <RowConstraints />
+                    <RowConstraints />
+                </rowConstraints>
 
-                        <Label text="Descripción:" GridPane.rowIndex="1" GridPane.columnIndex="0"/>
-                        <TextArea fx:id="descripcionArea" GridPane.rowIndex="1" GridPane.columnIndex="1" prefRowCount="3"/>
+                <Label text="Nombre" GridPane.columnIndex="0" GridPane.rowIndex="0" />
+                <TextField fx:id="nombreField" promptText="Azúcar" GridPane.columnIndex="1" GridPane.rowIndex="0" />
 
-                        <Label text="Preparación:" GridPane.rowIndex="2" GridPane.columnIndex="0"/>
-                        <TextArea fx:id="preparacionArea" GridPane.rowIndex="2" GridPane.columnIndex="1" prefRowCount="3"/>
-                    </children>
-                </GridPane>
+                <Label text="Descripción" GridPane.columnIndex="0" GridPane.rowIndex="1" />
+                <TextArea fx:id="descripcionArea" prefRowCount="2" promptText="Ingrediente dulce..."
+                          GridPane.columnIndex="1" GridPane.rowIndex="1" />
 
-                <TableView fx:id="ingredientesTable" prefHeight="250.0">
-                    <columns>
-                        <TableColumn fx:id="idColumn" text="ID" prefWidth="70.0"/>
-                        <TableColumn fx:id="nombreColumn" text="Nombre" prefWidth="150.0"/>
-                        <TableColumn fx:id="descripcionColumn" text="Descripción" prefWidth="200.0"/>
-                        <TableColumn fx:id="preparacionColumn" text="Preparación" prefWidth="200.0"/>
-                    </columns>
-                </TableView>
-            </children>
+                <Label text="Preparación" GridPane.columnIndex="0" GridPane.rowIndex="2" />
+                <TextArea fx:id="preparacionArea" prefRowCount="2" promptText="Mezclar con..."
+                          GridPane.columnIndex="1" GridPane.rowIndex="2" />
+            </GridPane>
+
+            <HBox alignment="CENTER_RIGHT" spacing="10">
+                <Label text="Buscar por" />
+                <ComboBox fx:id="cmbBusqueda" prefWidth="150.0" promptText="Elige un campo..." />
+                <TextField fx:id="txtBusqueda" promptText="Harina" HBox.hgrow="ALWAYS" />
+                <Button fx:id="btnListar" onAction="#onList" text="Listar" />
+                <Button fx:id="btnGuardar" onAction="#onSave" text="Guardar" />
+                <Button onAction="#onClear" text="Limpiar" />
+                <Button fx:id="btnActualizar" onAction="#onUpdate" text="Actualizar Registro" />
+                <Button fx:id="btnEliminar" onAction="#onDelete" text="Eliminar Registro" />
+            </HBox>
+
+            <TableView fx:id="ingredientesTable" prefHeight="300">
+                <columns>
+                    <TableColumn fx:id="idColumn" prefWidth="60" text="ID" />
+                    <TableColumn fx:id="nombreColumn" prefWidth="200" text="Nombre" />
+                    <TableColumn fx:id="descripcionColumn" prefWidth="200" text="Descripción" />
+                    <TableColumn fx:id="preparacionColumn" prefWidth="200" text="Preparación" />
+                </columns>
+            </TableView>
         </VBox>
-    </center>
-    <bottom>
-        <HBox spacing="10" alignment="CENTER_RIGHT">
-            <padding>
-                <Insets top="10" right="10" bottom="10" left="10"/>
-            </padding>
-            <Button text="Guardar" onAction="#onSave" defaultButton="true"/>
-            <Button text="Actualizar" onAction="#onUpdate"/>
-            <Button text="Eliminar" onAction="#onDelete"/>
-            <Button text="Limpiar" onAction="#onClear"/>
-        </HBox>
-    </bottom>
-</BorderPane>
+    </children>
+</AnchorPane>


### PR DESCRIPTION
## Summary
- populate the ingredient search combo box with the available fields and wire it to the controller
- restyle the ingredient form to mirror the cerveza layout and include the search controls inline with the action buttons
- clear the selected search field and text whenever the list is refreshed or the form is reset

## Testing
- mvn -q -DskipTests compile

------
https://chatgpt.com/codex/tasks/task_e_68f19be6564c832eb1fe9bc659a362ee