### PR TITLE
Add client-side search filtering to proportion ingredient form

### DIFF
--- a/src/main/java/org/cafeteria/cafeteria/controller/ProporcionIngredienteFormController.java
+++ b/src/main/java/org/cafeteria/cafeteria/controller/ProporcionIngredienteFormController.java
@@ -1,10 +1,11 @@
 package org.cafeteria.cafeteria.controller;
 
 import jakarta.persistence.EntityManager;
-import jakarta.persistence.TypedQuery;
 import javafx.beans.property.ReadOnlyObjectWrapper;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import javafx.collections.transformation.FilteredList;
+import javafx.collections.transformation.SortedList;
 import javafx.fxml.FXML;
 import javafx.scene.control.*;
 import javafx.util.StringConverter;
@@ -14,6 +15,7 @@ import org.cafeteria.cafeteria.model.ProporcionIngrediente;
 import org.cafeteria.cafeteria.model.Receta;
 
 import java.util.List;
+import java.util.function.Predicate;
 
 public class ProporcionIngredienteFormController {
     @FXML private ComboBox<Receta> recetaCombo;
@@ -28,16 +30,17 @@ public class ProporcionIngredienteFormController {
     @FXML private TextField searchTextField;
 
     private final ObservableList<ProporcionIngrediente> proporciones = FXCollections.observableArrayList();
+    private FilteredList<ProporcionIngrediente> filteredProporciones;
 
     @FXML private void initialize() {
         loadRecetas();
         loadIngredientes();
 
         // setup search combo
-        searchFieldCombo.setItems(FXCollections.observableArrayList("ID", "Receta", "Ingrediente", "Proporción"));
+        searchFieldCombo.setItems(FXCollections.observableArrayList("Todos", "ID", "Receta", "Ingrediente", "Proporción"));
         searchFieldCombo.getSelectionModel().selectFirst();
-        // trigger search on Enter
-        searchTextField.setOnAction(e -> onSearch());
+        searchFieldCombo.getSelectionModel().selectedItemProperty().addListener((o,a,b) -> applyFilter());
+        searchTextField.textProperty().addListener((o,a,b) -> applyFilter());
 
         idColumn.setCellValueFactory(cell -> new ReadOnlyObjectWrapper<>(cell.getValue().idProporcion));
         recetaColumn.setCellValueFactory(cell -> new ReadOnlyObjectWrapper<>(
@@ -48,7 +51,10 @@ public class ProporcionIngredienteFormController {
                 cell.getValue().ingrediente != null ? cell.getValue().ingrediente.nombre : ""));
         proporcionColumn.setCellValueFactory(cell -> new ReadOnlyObjectWrapper<>(cell.getValue().proporcion));
 
-        proporcionesTable.setItems(proporciones);
+        filteredProporciones = new FilteredList<>(proporciones, it -> true);
+        SortedList<ProporcionIngrediente> sorted = new SortedList<>(filteredProporciones);
+        sorted.comparatorProperty().bind(proporcionesTable.comparatorProperty());
+        proporcionesTable.setItems(sorted);
         proporcionesTable.getSelectionModel().selectedItemProperty().addListener((obs, old, selected) -> {
             if (selected != null) {
                 selectReceta(selected.receta != null ? selected.receta.idReceta : null);
@@ -193,66 +199,51 @@ public class ProporcionIngredienteFormController {
     }
 
     @FXML private void onSearch() {
-        String field = searchFieldCombo.getValue();
-        String text = searchTextField.getText();
-        if (text == null || text.isBlank()) {
-            alert(Alert.AlertType.WARNING, "Buscar", "Escribe texto para buscar o pulsa Limpiar.");
-            return;
-        }
-        EntityManager em = JPAUtil.em();
-        try {
-            TypedQuery<ProporcionIngrediente> query;
-            switch (field) {
-                case "ID":
-                    try {
-                        Long id = Long.parseLong(text.trim());
-                        query = em.createQuery("select p from ProporcionIngrediente p where p.idProporcion = :id", ProporcionIngrediente.class);
-                        query.setParameter("id", id);
-                    } catch (NumberFormatException nfe) {
-                        alert(Alert.AlertType.WARNING, "Buscar por ID", "ID inválido.");
-                        return;
-                    }
-                    break;
-                case "Receta":
-                    String tRec = "%" + text.trim().toLowerCase() + "%";
-                    query = em.createQuery(
-                            "select p from ProporcionIngrediente p join p.receta r join r.producto prod " +
-                                    "where lower(prod.descripcion) like :t or lower(r.tamano) like :t",
-                            ProporcionIngrediente.class);
-                    query.setParameter("t", tRec);
-                    break;
-                case "Ingrediente":
-                    String tIng = "%" + text.trim().toLowerCase() + "%";
-                    query = em.createQuery(
-                            "select p from ProporcionIngrediente p join p.ingrediente i where lower(i.nombre) like :t",
-                            ProporcionIngrediente.class);
-                    query.setParameter("t", tIng);
-                    break;
-                case "Proporción":
-                    String tProp = "%" + text.trim().toLowerCase() + "%";
-                    query = em.createQuery(
-                            "select p from ProporcionIngrediente p where lower(p.proporcion) like :t",
-                            ProporcionIngrediente.class);
-                    query.setParameter("t", tProp);
-                    break;
-                default:
-                    loadProporciones();
-                    return;
-            }
-            List<ProporcionIngrediente> lista = query.getResultList();
-            proporciones.setAll(lista);
-        } catch (Exception ex) {
-            alert(Alert.AlertType.ERROR, "Error al buscar", ex.getMessage());
-            ex.printStackTrace();
-        } finally { em.close(); }
+        applyFilter();
     }
 
     @FXML private void onClearSearch() {
         searchTextField.clear();
         searchFieldCombo.getSelectionModel().selectFirst();
-        loadProporciones();
+        applyFilter();
         searchTextField.requestFocus();
     }
+
+    private void applyFilter() {
+        if (filteredProporciones == null) return;
+        String query = searchTextField != null ? safeLower(searchTextField.getText()) : "";
+        String field = searchFieldCombo != null ? searchFieldCombo.getSelectionModel().getSelectedItem() : "Todos";
+        if (query.isBlank()) { filteredProporciones.setPredicate(it -> true); return; }
+        filteredProporciones.setPredicate(makePredicate(field, query));
+    }
+
+    private Predicate<ProporcionIngrediente> makePredicate(String field, String query) {
+        final String selectedField = field == null ? "Todos" : field;
+        return it -> {
+            String id = it.idProporcion != null ? String.valueOf(it.idProporcion).toLowerCase() : "";
+            String receta = "";
+            if (it.receta != null) {
+                String prodDesc = it.receta.producto != null ? it.receta.producto.descripcion : "";
+                receta = safeLower(prodDesc + " " + it.receta.tamano);
+            }
+            String ingrediente = it.ingrediente != null ? safeLower(it.ingrediente.nombre) : "";
+            String proporcion = safeLower(it.proporcion);
+            switch (selectedField) {
+                case "ID":
+                    return id.contains(query);
+                case "Receta":
+                    return receta.contains(query);
+                case "Ingrediente":
+                    return ingrediente.contains(query);
+                case "Proporción":
+                    return proporcion.contains(query);
+                default:
+                    return id.contains(query) || receta.contains(query) || ingrediente.contains(query) || proporcion.contains(query);
+            }
+        };
+    }
+
+    private String safeLower(String s) { return s == null ? "" : s.toLowerCase().trim(); }
 
     private void alert(Alert.AlertType type, String header, String content) {
         var a = new Alert(type);
@@ -269,6 +260,7 @@ public class ProporcionIngredienteFormController {
                             ProporcionIngrediente.class)
                     .getResultList();
             proporciones.setAll(lista);
+            applyFilter();
         } catch (Exception ex) {
             alert(Alert.AlertType.ERROR, "Error al cargar", ex.getMessage());
             ex.printStackTrace();


### PR DESCRIPTION
## Summary
- switch the proportion ingredient form to use the shared combo/text search filtering helpers
- keep the table backed by a filtered/sorted list so the search updates automatically

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f6819f5fb0832e936832ca10b14085