### PR TITLE
Enable editing paso detalle entries from PasoForm view

### DIFF
--- a/src/main/java/org/cafeteria/cafeteria/controller/PasoFormController.java
+++ b/src/main/java/org/cafeteria/cafeteria/controller/PasoFormController.java
@@ -52,6 +52,11 @@ public class PasoFormController {
 
         if (detallesList != null) {
             detallesList.setItems(detalles);
+            detallesList.getSelectionModel().selectedItemProperty().addListener((obs, old, selected) -> {
+                if (selected != null) {
+                    detalleArea.setText(selected);
+                }
+            });
         }
 
         // Filtrado/ordenado
@@ -67,6 +72,9 @@ public class PasoFormController {
                 detalles.setAll(selected.detalles == null ? List.of() : selected.detalles.stream()
                         .map(d -> d.pasoDetalle)
                         .collect(Collectors.toList()));
+                if (detallesList != null) {
+                    detallesList.getSelectionModel().clearSelection();
+                }
                 detalleArea.clear();
             }
         });
@@ -237,6 +245,9 @@ public class PasoFormController {
         detalleArea.clear();
         detalles.clear();
         pasosTable.getSelectionModel().clearSelection();
+        if (detallesList != null) {
+            detallesList.getSelectionModel().clearSelection();
+        }
         recetaCombo.requestFocus();
     }
 
@@ -292,6 +303,25 @@ public class PasoFormController {
         }
         detalles.add(detalle.trim());
         detalleArea.clear();
+        if (detallesList != null) {
+            detallesList.getSelectionModel().clearSelection();
+        }
+    }
+
+    @FXML private void onUpdateDetalle() {
+        if (detallesList == null) return;
+        int selectedIndex = detallesList.getSelectionModel().getSelectedIndex();
+        if (selectedIndex < 0) {
+            alert(Alert.AlertType.WARNING, "Seleccione un detalle", "Selecciona un detalle para actualizar.");
+            return;
+        }
+        String detalle = detalleArea != null ? detalleArea.getText() : null;
+        if (detalle == null || detalle.isBlank()) {
+            alert(Alert.AlertType.WARNING, "Campo requerido", "Captura el detalle actualizado antes de guardarlo.");
+            return;
+        }
+        detalles.set(selectedIndex, detalle.trim());
+        detallesList.getSelectionModel().select(selectedIndex);
     }
 
     @FXML private void onRemoveDetalle() {
@@ -302,6 +332,7 @@ public class PasoFormController {
             return;
         }
         detalles.remove(seleccionado);
+        detalleArea.clear();
     }
 
     private String buildRecetaLabel(Receta receta) {

--- a/src/main/resources/fxml/PasoForm.fxml
+++ b/src/main/resources/fxml/PasoForm.fxml
@@ -30,6 +30,7 @@
                     <TextArea fx:id="detalleArea" prefRowCount="3" promptText="Descripción detallada del paso"/>
                     <HBox spacing="10" alignment="CENTER_RIGHT">
                         <Button text="Agregar detalle" onAction="#onAddDetalle"/>
+                        <Button text="Actualizar detalle" onAction="#onUpdateDetalle"/>
                         <Button text="Eliminar detalle" onAction="#onRemoveDetalle"/>
                     </HBox>
                     <ListView fx:id="detallesList" prefHeight="120"/>


### PR DESCRIPTION
## Summary
- allow the Paso form to populate the detail editor when a list item is selected
- add support for updating and clearing selections in the list view
- expose an "Actualizar detalle" action in the Paso form UI

## Testing
- `./mvnw -q test` *(fails: Maven wrapper cannot download dependencies without network access)*

------
https://chatgpt.com/codex/tasks/task_e_68f9322ed530832ea5389c16c6694520